### PR TITLE
Use newest main commit sha when rebasing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10089,9 +10089,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "balena-lint -e ts src test",
     "lint:fix": "balena-lint --fix -e ts src test",
     "start": "probot run ./lib/index.js",
-    "test": "npm run build && vitest",
+    "test": "npm run rebuild && vitest",
     "prepare": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,11 +79,10 @@ export default (app: Probot) => {
 				ctx.log.error(withPrefix(messageParts.join(' ')));
 			} else if (isHttpError(error)) {
 				const {
-					status,
 					response: { data },
 				} = error;
 				ctx.log.error(
-					withPrefix(`Failed to rebase with status ${status}: ${data}`),
+					withPrefix(`Failed to rebase: ${JSON.stringify(data, null, 2)}`),
 				);
 			} else {
 				ctx.log.error(withPrefix(`Failed to rebase: ${error}`));


### PR DESCRIPTION
When cherry-picking, the base SHA being used was the base SHA that the PR was based off of, not the newest commit sha on main. This results in the following scenario:
- PR 1 and PR 2 are based off the same base commit
- PR 1 merges and updates the latest main commit
- PR 2 gets rebased, but references the outdated base commit as its base for rebase

Change-type: patch