### PR TITLE
Abort if feature branch HEAD sha has changed

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -221,6 +221,20 @@ export const rebase = async (
 			currentTree = result.tree.sha;
 		}
 
+		// Abort the rebase if PR HEAD SHA has changed,
+		// such as if a change to the feature branch was made since the rebase was started
+		const {
+			data: {
+				head: { sha: headSha },
+			},
+		} = await ctx.octokit.pulls.get({
+			...ctx.repo(),
+			pull_number: pr.number,
+		});
+		if (headSha !== pr.head.sha) {
+			throw new Error('Feature branch HEAD SHA has changed, aborting rebase');
+		}
+
 		// Update PR branch with rebased commits
 		await ctx.octokit.git.updateRef({
 			...ctx.repo(),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -246,7 +246,13 @@ describe('basejump', () => {
 				},
 			)
 			.reply(201)
-			// After cherry-picks: Update PR branch with rebased commit
+			// After cherry-picks: Check that feature branch HEAD SHA is unchanged
+			.get(`/repos/balena-user/github-app-test/pulls/${PR_NUMBER}`)
+			.reply(200, {
+				number: PR_NUMBER,
+				head: { sha: 'head-sha' },
+			})
+			// Update PR branch with rebased commit
 			.patch(
 				(uri) =>
 					uri.startsWith(
@@ -401,7 +407,13 @@ describe('basejump', () => {
 				},
 			)
 			.reply(201)
-			// After cherry-picks: Update PR branch with rebased commit
+			// After cherry-picks: Check that feature branch HEAD SHA is unchanged
+			.get(`/repos/balena-user/github-app-test/pulls/${PR_NUMBER}`)
+			.reply(200, {
+				number: PR_NUMBER,
+				head: { sha: 'head-sha' },
+			})
+			// Update PR branch with rebased commit
 			.patch(
 				(uri) =>
 					uri.startsWith(
@@ -426,6 +438,154 @@ describe('basejump', () => {
 				`/repos/balena-user/github-app-test/issues/comments/${COMMENT_ID}/reactions`,
 				{
 					content: 'rocket',
+				},
+			)
+			.reply(201)
+			// Delete eyes reaction
+			.delete(
+				`/repos/balena-user/github-app-test/issues/comments/${COMMENT_ID}/reactions/${EYES_REACTION_ID}`,
+			)
+			.reply(204);
+
+		await probot.receive({
+			name: 'issue_comment',
+			payload,
+		});
+
+		expect(mock.pendingMocks()).toHaveLength(0);
+	});
+
+	test('handles rebase where feature branch HEAD SHA has changed', async () => {
+		const mock = nock('https://api.github.com')
+			.post(`/app/installations/${INSTALLATION_ID}/access_tokens`)
+			.reply(200, { token: 'test' })
+			// Initial eyes reaction
+			.post(
+				`/repos/balena-user/github-app-test/issues/comments/${COMMENT_ID}/reactions`,
+			)
+			.reply(201, { id: EYES_REACTION_ID })
+			// Get PR (feature)
+			.get(`/repos/balena-user/github-app-test/pulls/${PR_NUMBER}`)
+			.reply(200, {
+				number: PR_NUMBER,
+				base: { ref: 'main', sha: 'base-sha' },
+				head: { ref: 'feature', sha: 'head-sha' },
+			})
+			// Compare branches, with behind_by indicating a rebase is required
+			.get('/repos/balena-user/github-app-test/compare/main...feature')
+			.reply(200, {
+				status: 'diverged',
+				ahead_by: 1,
+				behind_by: 2,
+				total_commits: 1,
+			})
+			// Get base commit
+			.get('/repos/balena-user/github-app-test/commits/main')
+			.reply(200, {
+				sha: 'base-sha',
+				commit: { tree: { sha: 'base-tree-sha' } },
+			})
+			// List feature branch commits
+			.get(`/repos/balena-user/github-app-test/pulls/${PR_NUMBER}/commits`)
+			.reply(200, [{ sha: 'commit-1' }])
+			// Create temp branch from base commit
+			.post('/repos/balena-user/github-app-test/git/refs', (body) => {
+				expect(body.ref.startsWith(`refs/heads/${TMP_BRANCH_PREFIX}`)).toEqual(
+					true,
+				);
+				expect(body.sha).toEqual('base-sha');
+				return true;
+			})
+			.reply(201)
+			// Cherry-pick 1: get the feature branch commit
+			.get('/repos/balena-user/github-app-test/git/commits/commit-1')
+			.reply(200, {
+				parents: [{ sha: 'parent' }],
+				author: { name: 'test', email: 'test@test.com' },
+				committer: { name: 'test', email: 'test@test.com' },
+				message: 'test commit',
+			})
+			// Cherry-pick 2: create a temp sibling commit
+			.post('/repos/balena-user/github-app-test/git/commits', (body) => {
+				expect(body.message).toEqual('Temp sibling of commit-1');
+				expect(body.parents[0]).toEqual('parent');
+				expect(body.tree).toEqual('base-tree-sha');
+				return true;
+			})
+			.reply(201, { sha: 'sibling-sha' })
+			// Cherry-pick 3: update ref to sibling commit
+			.patch(
+				(uri) => {
+					return uri.startsWith(
+						'/repos/balena-user/github-app-test/git/refs/heads%2Fbasejump%2Frebase-pr-',
+					);
+				},
+				(body) => {
+					expect(body.sha).toEqual('sibling-sha');
+					expect(body.force).toEqual(true);
+					return true;
+				},
+			)
+			.reply(201)
+			// Cherry-pick 4: merge original commit onto branch
+			.post('/repos/balena-user/github-app-test/merges', (body) => {
+				expect(body.base.startsWith(TMP_BRANCH_PREFIX)).toEqual(true);
+				expect(body.head).toEqual('commit-1');
+				expect(
+					body.commit_message.startsWith(
+						`Merge commit-1 into ${TMP_BRANCH_PREFIX}`,
+					),
+				).toEqual(true);
+				return true;
+			})
+			.reply(201, {
+				commit: {
+					tree: { sha: 'tmp-tree-sha' },
+				},
+			})
+			// Cherry-pick 5: create a new commit with original message
+			.post('/repos/balena-user/github-app-test/git/commits', (body) => {
+				expect(body.message).toEqual('test commit');
+				expect(body.parents[0]).toEqual('base-sha');
+				expect(body.tree).toEqual('tmp-tree-sha');
+				return true;
+			})
+			.reply(201, {
+				sha: 'rebased-commit-sha',
+				tree: { sha: 'rebased-tree-sha' },
+			})
+			// Cherry-pick 6: update ref to new commit
+			.patch(
+				(uri) =>
+					uri.startsWith(
+						'/repos/balena-user/github-app-test/git/refs/heads%2Fbasejump%2Frebase-pr-',
+					),
+				(body) => {
+					expect(body.sha).toEqual('rebased-commit-sha');
+					expect(body.force).toEqual(true);
+					return true;
+				},
+			)
+			.reply(201)
+			// After cherry-picks: Check that feature branch HEAD SHA is unchanged
+			// In this test, the HEAD SHA has changed, so the rebase should be aborted
+			.get(`/repos/balena-user/github-app-test/pulls/${PR_NUMBER}`)
+			.reply(200, {
+				number: PR_NUMBER,
+				head: { sha: 'head-sha-changed' },
+			})
+			// Clean up temp branch
+			.delete((uri) =>
+				uri.startsWith(
+					'/repos/balena-user/github-app-test/git/refs/heads%2Fbasejump%2Frebase-pr-',
+				),
+			)
+			.reply(204)
+			// Notify of rebase failure
+			.post(
+				`/repos/balena-user/github-app-test/issues/comments/${COMMENT_ID}/reactions`,
+				{
+					content: 'confused',
 				},
 			)
 			.reply(201)


### PR DESCRIPTION
This can occur if there was a feature branch code change since the rebase has started. Aborting in this case will prevent code change loss.

Change-type: patch